### PR TITLE
Even more parametric Derivation

### DIFF
--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -79,6 +79,7 @@
 module Nix.Derivation
     ( -- * Types
       Derivation(..)
+    , DerivationInputs(..)
     , DerivationOutput(..)
 
       -- * Parse derivations

--- a/src/Nix/Derivation/Builder.hs
+++ b/src/Nix/Derivation/Builder.hs
@@ -104,7 +104,6 @@ buildDerivationInputsWith filepath outputName (DerivationInputs {..}) =
         mapOf keyValue drvs
     <>  ","
     <>  setOf filepath srcs
-
   where
     keyValue (key, value) =
             "("

--- a/src/Nix/Derivation/Parser.hs
+++ b/src/Nix/Derivation/Parser.hs
@@ -170,9 +170,7 @@ textParser = do
 
                     pure (text0 : Data.Text.singleton char2 : textChunks)
 
-    textChunks <- loop
-
-    pure (Data.Text.concat textChunks)
+    Data.Text.concat <$> loop
 
 filepathParser :: Parser FilePath
 filepathParser = do

--- a/src/Nix/Derivation/Types.hs
+++ b/src/Nix/Derivation/Types.hs
@@ -12,15 +12,15 @@ module Nix.Derivation.Types
     ) where
 
 import Control.DeepSeq (NFData)
-import Data.Bifunctor (Bifunctor(bimap))
 import Data.Map (Map)
 import Data.Set (Set)
+import Data.Text (Text)
 import Data.Vector (Vector)
 import GHC.Generics (Generic)
 
 -- | A Nix derivation
-data Derivation fp txt = Derivation
-    { outputs   :: Map txt (DerivationOutput fp txt)
+data Derivation fp txt outputName drvOutput = Derivation
+    { outputs   :: Map outputName (drvOutput fp)
     -- ^ Outputs produced by this derivation where keys are output names
     , inputDrvs :: Map fp (Set txt)
     -- ^ Inputs that are derivations where keys specify derivation paths and
@@ -38,30 +38,21 @@ data Derivation fp txt = Derivation
     -- derivation
     } deriving (Eq, Generic, Ord, Show)
 
-instance (NFData a, NFData b) => NFData (Derivation a b)
+instance ( NFData fp
+         , NFData txt
+         , NFData outputName
+         , NFData (drvOutput fp)
+         )
+         => NFData (Derivation fp txt outputName drvOutput)
 
 -- | An output of a Nix derivation
-data DerivationOutput fp txt = DerivationOutput
+data DerivationOutput fp = DerivationOutput
     { path     :: fp
     -- ^ Path where the output will be saved
-    , hashAlgo :: txt
+    , hashAlgo :: Text
     -- ^ Hash used for expected hash computation
-    , hash     :: txt
+    , hash     :: Text
     -- ^ Expected hash
     } deriving (Eq, Generic, Ord, Show)
 
-instance (NFData a, NFData b) => NFData (DerivationOutput a b)
-
-instance Functor (DerivationOutput fp) where
-  fmap f DerivationOutput{..} = DerivationOutput
-    { path = path
-    , hashAlgo = f hashAlgo
-    , hash = f hash
-    }
-
-instance Bifunctor DerivationOutput where
-  bimap f g DerivationOutput{..} = DerivationOutput
-    { path = f path
-    , hashAlgo = g hashAlgo
-    , hash = g hash
-    }
+instance (NFData a) => NFData (DerivationOutput a)

--- a/src/Nix/Derivation/Types.hs
+++ b/src/Nix/Derivation/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures    #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 -- | Shared types
 

--- a/src/Nix/Derivation/Types.hs
+++ b/src/Nix/Derivation/Types.hs
@@ -8,6 +8,7 @@
 module Nix.Derivation.Types
     ( -- * Types
       Derivation(..)
+    , DerivationInputs(..)
     , DerivationOutput(..)
     ) where
 
@@ -19,14 +20,11 @@ import Data.Vector (Vector)
 import GHC.Generics (Generic)
 
 -- | A Nix derivation
-data Derivation fp txt outputName drvOutput = Derivation
+data Derivation fp txt outputName drvOutput drvInputs = Derivation
     { outputs   :: Map outputName (drvOutput fp)
     -- ^ Outputs produced by this derivation where keys are output names
-    , inputDrvs :: Map fp (Set txt)
-    -- ^ Inputs that are derivations where keys specify derivation paths and
-    -- values specify which output names are used by this derivation
-    , inputSrcs :: Set fp
-    -- ^ Inputs that are sources
+    , inputs    :: drvInputs fp outputName
+    -- ^ Inputs (sources and derivations)
     , platform  :: txt
     -- ^ Platform required for this derivation
     , builder   :: txt
@@ -42,8 +40,19 @@ instance ( NFData fp
          , NFData txt
          , NFData outputName
          , NFData (drvOutput fp)
+         , NFData (drvInputs fp outputName)
          )
-         => NFData (Derivation fp txt outputName drvOutput)
+         => NFData (Derivation fp txt outputName drvOutput drvInputs)
+
+data DerivationInputs fp drvOutput = DerivationInputs
+    { drvs :: Map fp (Set drvOutput)
+    -- ^ Inputs that are derivations where keys specify derivation paths and
+    -- values specify which output names are used by this derivation
+    , srcs :: Set fp
+    -- ^ Inputs that are sources
+    } deriving (Eq, Generic, Ord, Show)
+
+instance (NFData a, NFData b) => NFData (DerivationInputs a b)
 
 -- | An output of a Nix derivation
 data DerivationOutput fp = DerivationOutput

--- a/tests/Property.hs
+++ b/tests/Property.hs
@@ -34,14 +34,14 @@ instance Arbitrary (DerivationInputs FilePath Text) where
     arbitrary = do
         drvs <- arbitrary
         srcs <- arbitrary
-        return (DerivationInputs {..})
+        pure DerivationInputs {..}
 
 instance Arbitrary (DerivationOutput FilePath) where
     arbitrary = do
         path     <- arbitrary
         hashAlgo <- arbitrary
         hash     <- arbitrary
-        return (DerivationOutput {..})
+        pure DerivationOutput {..}
 
 instance Arbitrary (Derivation FilePath Text Text DerivationOutput DerivationInputs) where
     arbitrary = do
@@ -51,7 +51,7 @@ instance Arbitrary (Derivation FilePath Text Text DerivationOutput DerivationInp
         builder   <- arbitrary
         args      <- arbitrary
         env       <- arbitrary
-        return (Derivation {..})
+        pure Derivation {..}
 
 property :: Derivation FilePath Text Text DerivationOutput DerivationInputs -> Bool
 property derivation0 = either == Right derivation0

--- a/tests/Property.hs
+++ b/tests/Property.hs
@@ -26,14 +26,14 @@ instance Arbitrary Text where
 instance Arbitrary a => Arbitrary (Vector a) where
     arbitrary = fmap Data.Vector.fromList arbitrary
 
-instance Arbitrary (DerivationOutput FilePath Text) where
+instance Arbitrary (DerivationOutput FilePath) where
     arbitrary = do
         path     <- arbitrary
         hashAlgo <- arbitrary
         hash     <- arbitrary
         return (DerivationOutput {..})
 
-instance Arbitrary (Derivation FilePath Text) where
+instance Arbitrary (Derivation FilePath Text Text DerivationOutput) where
     arbitrary = do
         outputs   <- arbitrary
         inputDrvs <- arbitrary
@@ -44,7 +44,7 @@ instance Arbitrary (Derivation FilePath Text) where
         env       <- arbitrary
         return (Derivation {..})
 
-property :: Derivation FilePath Text -> Bool
+property :: Derivation FilePath Text Text DerivationOutput -> Bool
 property derivation0 = either == Right derivation0
   where
     builder = Nix.Derivation.buildDerivation derivation0

--- a/tests/Property.hs
+++ b/tests/Property.hs
@@ -9,7 +9,11 @@ module Main where
 import Data.Text (Text)
 import Data.Vector (Vector)
 import System.FilePath
-import Nix.Derivation (Derivation(..), DerivationOutput(..))
+import Nix.Derivation
+    ( Derivation(..)
+    , DerivationInputs(..)
+    , DerivationOutput(..)
+    )
 import Prelude hiding (FilePath, either)
 import Test.QuickCheck (Arbitrary(..))
 
@@ -26,6 +30,12 @@ instance Arbitrary Text where
 instance Arbitrary a => Arbitrary (Vector a) where
     arbitrary = fmap Data.Vector.fromList arbitrary
 
+instance Arbitrary (DerivationInputs FilePath Text) where
+    arbitrary = do
+        drvs <- arbitrary
+        srcs <- arbitrary
+        return (DerivationInputs {..})
+
 instance Arbitrary (DerivationOutput FilePath) where
     arbitrary = do
         path     <- arbitrary
@@ -33,18 +43,17 @@ instance Arbitrary (DerivationOutput FilePath) where
         hash     <- arbitrary
         return (DerivationOutput {..})
 
-instance Arbitrary (Derivation FilePath Text Text DerivationOutput) where
+instance Arbitrary (Derivation FilePath Text Text DerivationOutput DerivationInputs) where
     arbitrary = do
         outputs   <- arbitrary
-        inputDrvs <- arbitrary
-        inputSrcs <- arbitrary
+        inputs    <- arbitrary
         platform  <- arbitrary
         builder   <- arbitrary
         args      <- arbitrary
         env       <- arbitrary
         return (Derivation {..})
 
-property :: Derivation FilePath Text Text DerivationOutput -> Bool
+property :: Derivation FilePath Text Text DerivationOutput DerivationInputs -> Bool
 property derivation0 = either == Right derivation0
   where
     builder = Nix.Derivation.buildDerivation derivation0


### PR DESCRIPTION
Parametrized on
* `outputName`
* `drvOutput`
* `drvInputs`

Normalizes `Derivation` inputs and makes it accept different types for all these, which is required to tie some loose ends on `hnix/hnix-store` side.

I've also removed the (now) useless `Functor` and `Bifunctor` instances and passed the lib thru hlint, which doesn't produce any warnings now.

`DeriviationOutput` is no longer parametrized with `text` as we replace it completely on our side with
```haskell
-- | Output of the derivation
data DerivationOutput outputName = DerivationOutput
  { derivationOutputHash :: DSum HashAlgo Digest
  -- ^ Hash modulo of the derivation
  , derivationOutputName :: outputName
  -- ^ Name of the output
  } deriving (Eq, Generic, Ord, Show)
```

I've realised this when I've tried to implement Nixes `Realisation` type :upside_down_face:, which also uses `DerivationOutput` 

I hope this accommodates all our needs, and is parametric enough for now - we might want to differentiate between the other `txt` types in the future though, using some simple `newtype` wrappers.

I'm tempted to add a type alias to make this look less awkward for downstream users that don't need this level of parametrization (`nix-diff`, `nix-graph`), but I'm not sure if it's worth it because then you need to import both `Derivation(..)` for the fields and the type alias.

I'll try to actually use this first, to see if really fits and then I would add a version bump (possibly `CHANGELOG` as well), ask you for a release and do the downstream PRs.